### PR TITLE
Example Alibis

### DIFF
--- a/client/src/components/WikiArticle.tsx
+++ b/client/src/components/WikiArticle.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import translate, { langText, translateChecked } from "../game/lang";
 import StyledText, { DUMMY_NAMES_KEYWORD_DATA, DUMMY_NAMES_SENDER_KEYWORD_DATA, StyledTextProps } from "./StyledText";
 import { ROLE_SETS, getAllRoles, getRolesFromRoleSet } from "../game/roleListState.d";
-import ChatElement, { ChatMessageVariant } from "./ChatMessage";
+import ChatElement from "./ChatMessage";
 import DUMMY_NAMES from "../resources/dummyNames.json";
 import { ARTICLES, GeneratedArticle, getArticleTitle, WikiArticleLink, wikiPageIsEnabled } from "./WikiArticleLink";
 import "./wiki.css";
@@ -29,7 +29,9 @@ export default function WikiArticle(props: {
         case "role": {
             const role = path[1] as Role;
             const roleData = roleJsonData()[role];
-            const chatMessages = roleData.chatMessages as ChatMessageVariant[];
+            const chatMessages = roleData.chatMessages;
+            const exampleAlibi = translateChecked("wiki.article.role."+role+".exampleAlibi");
+            const exampleAlibiDescription = translateChecked("wiki.article.role."+role+".exampleAlibi.description");
 
             return <section className="wiki-article">
                 <div>
@@ -78,6 +80,17 @@ export default function WikiArticle(props: {
                             playerSenderKeywordData={DUMMY_NAMES_SENDER_KEYWORD_DATA}
                         />
                     )}
+                </div>}
+                {exampleAlibi && <div className="wiki-message-section">
+                    <WikiStyledText>
+                        {"### "+translate("wiki.article.role.exampleAlibi")+"\n"}
+                    </WikiStyledText>
+                    {exampleAlibiDescription && <WikiStyledText>
+                        {exampleAlibiDescription}
+                    </WikiStyledText>}
+                    <blockquote>
+                        <WikiStyledText>{replaceMentions(exampleAlibi, DUMMY_NAMES)}</WikiStyledText>
+                    </blockquote>
                 </div>}
                 <DetailsSummary 
                     summary={translate("wiki.article.role.details")}

--- a/client/src/resources/lang/en_us.json
+++ b/client/src/resources/lang/en_us.json
@@ -1414,6 +1414,7 @@
     "wiki.article.role.noReminder": "There is no reminder section written for this role.",
     "wiki.article.role.guide": "Abilities",
     "wiki.article.role.noGuide": "There is no abilities section written for this role.",
+    "wiki.article.role.exampleAlibi": "Alibi Example",
 
     "wiki.article.role.abilities": "Abilities",
     "wiki.article.role.noAbilities": "There is no abilities section written for this role.",
@@ -1488,12 +1489,16 @@
     "wiki.article.role.psychic.abilities":"- Each night, choose a player to receive a vision\n    - On even nights, the vision lists 2 players. At least one of them is a town loyalist\n    - On odd nights, the vision lists three players. At least one of them is not a town loyalist",
     "wiki.article.role.psychic.attributes":"- Besides the player you visit, the other players in your vision are chosen randomly.\n- There the random players are guaranteed to have these properties:\n    - If it is a good vision, the player doesn't have suspicious aura\n    - If it is an evil vision, the player doesn't innocent aura\n    - The player is alive\n    - A vision never lists the same player twice\n    - You can't be the random player in your own vision\n- If there are not enough players who satisfy the required properties for random players in your vision, the vision fails",
     "wiki.article.role.psychic.extra": "- Your ability works on the player you visit, if you visit nobody then your ability doesnt work\n- The order of the players in the visions are randomized",
+    "wiki.article.role.psychic.exampleAlibi": "Psychic\nN1: @6* @1 @2\nN2: (@7) @4\nN3: @3\n@8 @9",
+    "wiki.article.role.psychic.exampleAlibi.description": "As the psychic, it's important to be clear about which player you selected. Some people use an asterisk, surround the selection with parentheses, or use a separate line. Here's an example of both:",
 
     "wiki.article.role.auditor.reminder": "At night, select up to 2 outlines to learn what roles were generated from them.",
     "wiki.article.role.auditor.guide": "- At night, choose up to 2 outlines from the list\n    - For each outline, you are told up to 4 roles, one of those roles were assigned to a player from that outline, and the other roles are random\n    - You visit the player who was assigned that role, but you are not told who that player is\n    - You are told the minimum of 4 and the number the roles from that role outline - 1\n    - You can't choose an outline with only 1 role",
     "wiki.article.role.auditor.abilities":"- At night, choose up to 2 outlines from the list\n    - For each outline, you are told up to 4 roles, one of those roles were assigned to a player from that outline, and the other roles are random\n    - You visit the player who was assigned that role, but you are not told who that player is\n    - You are told the minimum of 4 and the number the roles from that role outline - 1\n    - You can't choose an outline with only 1 role",
     "wiki.article.role.auditor.attributes":"- You are not told the names of any players\n- The random role you are told is from the outline you chose",
     "wiki.article.role.auditor.extra":"- Your ability works independently of your visits, Your visit getting transported or getting possessed doesn't usually impact your ability\n    - If you are blocked, you don't get results, but you can select that outline again\n- It is possible for you to visit dead players",
+    "wiki.article.role.auditor.exampleAlibi":"Auditor\nN1:\nTC1 -> Gossip, Detective, Snoop, Philosopher\nTC2 -> Lookout, Escort, Doctor, Cop\nN2:\nSS1 -> Hypnotist, Reeducator, Framer, Forger\nSS U Minion -> Warper, Informant, Disguiser, Scarecrow",
+    "wiki.article.role.auditor.exampleAlibi.description":"The auditor gets a lot of information, so make sure to format your alibi so it is as easy to read as possible. Here's an example:",
 
     "wiki.article.role.snoop.reminder": "At night, select a player to learn if they are a town loyalist, but you can't tell if you are visited by at least one non town loyalist, or at least two town loyalists.",
     "wiki.article.role.snoop.guide": "- At night, select a player. You are either told that they are a town loyalist, or that you can't tell if they are a townie\n    - You can't tell what your target was if:\n        - They aren't a townie\n        - You are visited by at least one non town loyalist, or at least two town loyalists\n        - They have a suspicious aura\n\n    - Otherwise, you are told they are a town loyalist",


### PR DESCRIPTION
Add the ability for the Midnight Manual to have example alibis for some roles.

This PR adds them only for Auditor and Psychic, but it is possible to add it to any role.

<img width="1783" height="1446" alt="image" src="https://github.com/user-attachments/assets/e17029c4-c4a3-4ae9-bb73-0b8bee7983ed" />
<img width="1783" height="1609" alt="image" src="https://github.com/user-attachments/assets/bf9aa434-d8ef-4e43-87a8-51b4671c832a" />

The auditor alibi will look a lot nicer once #867 is merged, since the "TC" in TC1 and TC2 will appear colored, prompting users that don't know what it means to click on it and learn.